### PR TITLE
Multiselect, Import/Export, Clear button and moved data folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 __pycache__/**
 prompt_library_data.json

--- a/README.md
+++ b/README.md
@@ -23,9 +23,22 @@ Includes a dedicated **Random Prompt** node for automatic prompt variation on ev
 | ✎ **Edit in place** | Modal editors for prompts and categories |
 | 🎲 **Random mode** | Separate node that picks a random prompt from selected categories at every run |
 | 🌱 **Seed control** | Fixed seed for reproducible results, `-1` for true randomness |
+| 🔀 **Random segments** | Support for `{abc|xyz|123}` syntax (supports nesting) |
 | 💾 **Auto-persist** | All data saved to `prompt_library_data.json` |
 
 ---
+
+### 🔡 String Concatenate
+
+A utility node that concatenates multiple string inputs with a custom delimiter. The number of inputs can be adjusted dynamically, and a live preview of the result is shown on the node.
+
+| Input | Description |
+|---|---|
+| `delimiter` | The string used to join the inputs (e.g., ", ", " ", "\n") |
+| `input_count` | How many string inputs to show (2 to 20) |
+| `string1-N` | Dynamic string inputs (can be connected from other nodes) |
+
+Returns a single concatenated `STRING`.
 
 ## 🚀 Installation
 
@@ -58,7 +71,9 @@ Browse your library, search, manage categories, and load any prompt with one cli
 
 | Input | Description |
 |---|---|
-| `prompt_id` | Auto-filled when you click ↗ on a card in the UI |
+| `prompt_ids` | Auto-filled when you click a card in the UI |
+| `prompts` | Human-readable list of selected prompt titles |
+| `seed` | `-1` = truly random on every run · any other value = reproducible result (for random segments `{a|b}`) |
 | `prefix` *(optional)* | Text prepended to the positive prompt |
 | `suffix` *(optional)* | Text appended to the positive prompt |
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Returns a single concatenated `STRING`.
 1. Clone this repo into your ComfyUI custom nodes directory:
 
 ```bash
-git clone https://github.com/florestefano1975/ComfyUI-Prompt-Library
+git clone https://github.com/NoudH/ComfyUI-Prompt-Library
 ```
 
 2. Restart ComfyUI.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,13 @@ Includes a dedicated **Random Prompt** node for automatic prompt variation on ev
 | 🏷️ **Tags** | Comma-separated tags on every prompt |
 | ➖ **Negative prompts** | Store positive + negative together |
 | ↗ **One-click use** | Instantly loads the selected prompt into the node |
+| 🧹 **Clear selection** | Deselect all prompts from the manual node without deleting library data |
+| ↕ **Import / Export** | Replace the library from a local JSON file or download a backup |
 | ✎ **Edit in place** | Modal editors for prompts and categories |
 | 🎲 **Random mode** | Separate node that picks a random prompt from selected categories at every run |
 | 🌱 **Seed control** | Fixed seed for reproducible results, `-1` for true randomness |
 | 🔀 **Random segments** | Support for `{abc|xyz|123}` syntax (supports nesting) |
-| 💾 **Auto-persist** | All data saved to `prompt_library_data.json` |
+| 💾 **Auto-persist** | All data saved to `prompt_library_data.json` in the ComfyUI user directory |
 
 ---
 
@@ -59,6 +61,10 @@ git clone https://github.com/NoudH/ComfyUI-Prompt-Library
 ## 📚 Node 1 — Prompt Library (manual)
 
 Browse your library, search, manage categories, and load any prompt with one click.
+
+The panel header provides **Import** and **Export** controls. Import reads a local JSON file and, after confirmation, replaces the complete shared library. Invalid files are rejected without changing the current data. Export downloads the latest persisted library as `prompt_library_data.json`. Exporting a backup is recommended before importing.
+
+Use **Clear selection** above the prompt grid to clear the current node's `prompt_ids` and `prompts` values without deleting any saved prompts or changing the Random Prompt node's category selection.
 
 ### Outputs
 
@@ -113,8 +119,22 @@ The selection is stored in the `category_ids` widget and persists with the saved
 
 ## 📂 Data file
 
-All prompts and categories are stored in `prompt_library_data.json` in the node folder.
-You can back it up, version-control it, or share it between machines.
+All prompts and categories are stored as `prompt_library_data.json` in the configured ComfyUI user directory returned by `folder_paths.get_user_directory()`. This location follows ComfyUI's `--user-directory` setting and keeps library data outside the custom node installation.
+
+On first use after upgrading, an existing `prompt_library_data.json` in the custom node folder is copied automatically when no file exists at the new location. The original file is retained as a backup.
+
+You can back up, version-control, or share the user-directory data file between machines.
+
+Import and export use the same JSON root structure:
+
+```json
+{
+  "categories": [],
+  "prompts": []
+}
+```
+
+Import validates IDs, category relationships, prompt fields, tags, and colors before atomically replacing the data file.
 
 ---
 
@@ -134,6 +154,12 @@ You can back it up, version-control it, or share it between machines.
 ---
 
 ## 📝 Changelog
+
+### Next release
+- Moved prompt library storage to the configured ComfyUI user directory, with automatic migration from the legacy node-local file
+- Added JSON import with confirmation, schema validation, and atomic persistence
+- Added JSON export for downloading the latest persisted library
+- Added a clear-selection control for the manual Prompt Library node
 
 ### v1.3
 - 🎲 Added **Prompt Library Random** node (`PromptLibraryRandomNode`)

--- a/prompt_library.py
+++ b/prompt_library.py
@@ -1,6 +1,8 @@
 import json
 import os
 import uuid
+import re
+import random
 from datetime import datetime
 from aiohttp import web
 from server import PromptServer
@@ -24,6 +26,37 @@ def save_library(data):
     """Save the prompt library to disk."""
     with open(LIBRARY_FILE, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def process_random_segments(text, rng=None):
+    """
+    Finds segments like {abc|xyz|123} and picks one choice randomly.
+    Supports nested segments like {a|{b|c}}.
+    Can use a provided random.Random instance for deterministic results.
+    """
+    if not text:
+        return text
+
+    if rng is None:
+        rng = random
+
+    def replace_choice(match):
+        choices = match.group(1).split("|")
+        return rng.choice(choices)
+
+    # Regex: find anything inside { } that contains at least one |
+    # and does NOT contain nested brackets. This ensures we process from inside out.
+    pattern = r"\{([^{}]*\|[^{}]*)\}"
+    
+    # Process from the inside out until no more patterns match
+    new_text = text
+    while True:
+        processed = re.sub(pattern, replace_choice, new_text)
+        if processed == new_text:
+            break
+        new_text = processed
+        
+    return new_text
 
 
 # ──────────────────────────────────────────────
@@ -147,7 +180,9 @@ class PromptLibraryNode:
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "prompt_id": ("STRING", {"default": ""}),
+				"prompts": ("STRING", {"default": ""}),
+                "prompt_ids": ("STRING", {"default": ""}),
+                "seed": ("INT", {"default": -1, "min": -1, "max": 2**31 - 1}),
             },
             "optional": {
                 "prefix": ("STRING", {"default": "", "multiline": False}),
@@ -161,14 +196,26 @@ class PromptLibraryNode:
     CATEGORY = "utils/prompts"
     OUTPUT_NODE = False
 
-    def load_prompt(self, prompt_id, prefix="", suffix=""):
+    def load_prompt(self, prompts="", prompt_ids="", seed=-1, prefix="", suffix=""):
         library = load_library()
-        for p in library["prompts"]:
-            if p["id"] == prompt_id:
-                positive = " ".join(filter(None, [prefix.strip(), p["text"].strip(), suffix.strip()]))
-                return (positive, p.get("negative", ""))
-        # Return empty if not found
-        return (prefix.strip(), "")
+        ids = [pid.strip() for pid in prompt_ids.split(",") if pid.strip()]
+        matched = [p for p in library["prompts"] if p["id"] in ids]
+        # Preserve the order from prompt_ids
+        id_order = {pid: i for i, pid in enumerate(ids)}
+        matched.sort(key=lambda p: id_order.get(p["id"], 0))
+
+        texts = [p["text"].strip() for p in matched if p["text"].strip()]
+        negatives = [p["negative"].strip() for p in matched if p.get("negative", "").strip()]
+
+        positive = ", ".join(filter(None, [prefix.strip()] + texts + [suffix.strip()]))
+        negative = ", ".join(negatives)
+
+        # Apply randomization
+        rng = random.Random(seed if seed != -1 else None)
+        positive = process_random_segments(positive, rng)
+        negative = process_random_segments(negative, rng)
+
+        return (positive, negative)
 
 
 class PromptLibraryRandomNode:
@@ -199,8 +246,6 @@ class PromptLibraryRandomNode:
     OUTPUT_NODE = False
 
     def pick_random(self, category_ids, seed=-1, prefix="", suffix=""):
-        import random
-
         library = load_library()
 
         if not category_ids.strip():
@@ -229,15 +274,56 @@ class PromptLibraryRandomNode:
         chosen = rng.choice(pool)
 
         positive = " ".join(filter(None, [prefix.strip(), chosen["text"].strip(), suffix.strip()]))
-        return (positive, chosen.get("negative", ""), chosen.get("title", ""), chosen["id"])
+        negative = chosen.get("negative", "")
 
+        # Apply randomization using the same seed for reproducibility if seed != -1
+        positive = process_random_segments(positive, rng)
+        negative = process_random_segments(negative, rng)
+
+        return (positive, negative, chosen.get("title", ""), chosen["id"])
+
+
+class StringConcatenateNode:
+    """
+    A simple node that concatenates n string inputs.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "delimiter": ("STRING", {"default": ", "}),
+                "input_count": ("INT", {"default": 2, "min": 2, "max": 20, "step": 1}),
+            },
+            "optional": {
+                **{
+                    f"string{i}": ("STRING", {"forceInput": True, "default": ""})
+                    for i in range(1, 21)
+                }
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("Result",)
+    FUNCTION = "concatenate"
+    CATEGORY = "utils/strings"
+
+    def concatenate(self, delimiter, input_count, **kwargs):
+        values = []
+        for i in range(1, input_count + 1):
+            k = f"string{i}"
+            if k in kwargs:
+                values.append(str(kwargs[k]))
+        return (delimiter.join(values),)
 
 NODE_CLASS_MAPPINGS = {
     "PromptLibraryNode": PromptLibraryNode,
     "PromptLibraryRandomNode": PromptLibraryRandomNode,
+    "StringConcatenateNode": StringConcatenateNode,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "PromptLibraryNode": "📚 Prompt Library",
     "PromptLibraryRandomNode": "🎲 Prompt Library — Random",
+    "StringConcatenateNode": "🔡 String Concatenate",
 }

--- a/prompt_library.py
+++ b/prompt_library.py
@@ -3,29 +3,194 @@ import os
 import uuid
 import re
 import random
+import stat
+import tempfile
 from datetime import datetime
 from aiohttp import web
+import folder_paths
 from server import PromptServer
 
-# Path to store the prompt library data
-LIBRARY_FILE = os.path.join(os.path.dirname(__file__), "prompt_library_data.json")
+LIBRARY_FILENAME = "prompt_library_data.json"
+LEGACY_LIBRARY_FILE = os.path.join(os.path.dirname(__file__), LIBRARY_FILENAME)
+LIBRARY_FILE = os.path.join(folder_paths.get_user_directory(), LIBRARY_FILENAME)
+
+
+class LibraryValidationError(ValueError):
+    """Raised when replacement library data does not match the expected schema."""
+
+
+def validate_library(data):
+    """Validate and normalize a complete prompt library."""
+    if not isinstance(data, dict):
+        raise LibraryValidationError("The library root must be a JSON object.")
+
+    categories = data.get("categories")
+    prompts = data.get("prompts")
+    if not isinstance(categories, list) or not isinstance(prompts, list):
+        raise LibraryValidationError("The library must contain categories and prompts arrays.")
+
+    category_ids = set()
+    parent_by_id = {}
+    for index, category in enumerate(categories):
+        label = f"Category at index {index}"
+        if not isinstance(category, dict):
+            raise LibraryValidationError(f"{label} must be an object.")
+
+        category_id = category.get("id")
+        if (
+            not isinstance(category_id, str)
+            or not category_id.strip()
+            or category_id != category_id.strip()
+            or "," in category_id
+        ):
+            raise LibraryValidationError(
+                f"{label} must have a non-empty string id without commas or outer whitespace."
+            )
+        if category_id in category_ids:
+            raise LibraryValidationError(f"Duplicate category id: {category_id}")
+        category_ids.add(category_id)
+
+        name = category.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise LibraryValidationError(f"{label} must have a non-empty string name.")
+
+        parent_id = category.get("parent_id")
+        if parent_id is not None and (not isinstance(parent_id, str) or not parent_id.strip()):
+            raise LibraryValidationError(f"{label} has an invalid parent_id.")
+        parent_by_id[category_id] = parent_id
+
+        color = category.get("color", "#6366f1")
+        if not isinstance(color, str) or not re.fullmatch(r"#[0-9a-fA-F]{6}", color):
+            raise LibraryValidationError(f"{label} has an invalid color; use a six-digit hex color.")
+        category.setdefault("parent_id", None)
+        category.setdefault("color", "#6366f1")
+
+        created_at = category.get("created_at")
+        if created_at is not None and not isinstance(created_at, str):
+            raise LibraryValidationError(f"{label} has an invalid created_at value.")
+
+    for category_id, parent_id in parent_by_id.items():
+        if parent_id is not None and parent_id not in category_ids:
+            raise LibraryValidationError(
+                f"Category {category_id} references an unknown parent category."
+            )
+        if parent_id == category_id:
+            raise LibraryValidationError(f"Category {category_id} cannot be its own parent.")
+
+        visited = {category_id}
+        current_id = parent_id
+        while current_id is not None:
+            if current_id in visited:
+                raise LibraryValidationError("Category parent references contain a cycle.")
+            visited.add(current_id)
+            current_id = parent_by_id.get(current_id)
+
+    prompt_ids = set()
+    for index, prompt in enumerate(prompts):
+        label = f"Prompt at index {index}"
+        if not isinstance(prompt, dict):
+            raise LibraryValidationError(f"{label} must be an object.")
+
+        prompt_id = prompt.get("id")
+        if (
+            not isinstance(prompt_id, str)
+            or not prompt_id.strip()
+            or prompt_id != prompt_id.strip()
+            or "," in prompt_id
+        ):
+            raise LibraryValidationError(
+                f"{label} must have a non-empty string id without commas or outer whitespace."
+            )
+        if prompt_id in prompt_ids:
+            raise LibraryValidationError(f"Duplicate prompt id: {prompt_id}")
+        prompt_ids.add(prompt_id)
+
+        title = prompt.get("title")
+        text = prompt.get("text")
+        if not isinstance(title, str) or not title.strip():
+            raise LibraryValidationError(f"{label} must have a non-empty string title.")
+        if not isinstance(text, str) or not text.strip():
+            raise LibraryValidationError(f"{label} must have non-empty string text.")
+
+        category_id = prompt.get("category_id")
+        if category_id is not None and (
+            not isinstance(category_id, str) or not category_id.strip()
+        ):
+            raise LibraryValidationError(f"{label} has an invalid category_id.")
+        if category_id is not None and category_id not in category_ids:
+            raise LibraryValidationError(f"{label} references an unknown category.")
+
+        negative = prompt.get("negative", "")
+        if not isinstance(negative, str):
+            raise LibraryValidationError(f"{label} has an invalid negative prompt.")
+
+        tags = prompt.get("tags", [])
+        if not isinstance(tags, list) or any(not isinstance(tag, str) for tag in tags):
+            raise LibraryValidationError(f"{label} tags must be an array of strings.")
+        prompt.setdefault("category_id", None)
+        prompt.setdefault("negative", "")
+        prompt.setdefault("tags", [])
+
+        for field in ("created_at", "updated_at"):
+            value = prompt.get(field)
+            if value is not None and not isinstance(value, str):
+                raise LibraryValidationError(f"{label} has an invalid {field} value.")
+
+    return data
+
+
+def migrate_legacy_library():
+    """Copy legacy node-local data to the ComfyUI user directory once."""
+    if os.path.exists(LIBRARY_FILE) or not os.path.exists(LEGACY_LIBRARY_FILE):
+        return
+
+    try:
+        with open(LEGACY_LIBRARY_FILE, "r", encoding="utf-8") as legacy_file:
+            legacy_data = validate_library(json.load(legacy_file))
+        save_library(legacy_data)
+    except (OSError, UnicodeError, json.JSONDecodeError, LibraryValidationError):
+        pass
 
 
 def load_library():
-    """Load the prompt library from disk."""
+    """Load the prompt library from the configured ComfyUI user directory."""
+    migrate_legacy_library()
     if os.path.exists(LIBRARY_FILE):
         try:
-            with open(LIBRARY_FILE, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
+            with open(LIBRARY_FILE, "r", encoding="utf-8") as library_file:
+                return json.load(library_file)
+        except (OSError, UnicodeError, json.JSONDecodeError):
             pass
     return {"categories": [], "prompts": []}
 
 
 def save_library(data):
-    """Save the prompt library to disk."""
-    with open(LIBRARY_FILE, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
+    """Atomically save the prompt library in the ComfyUI user directory."""
+    directory = os.path.dirname(LIBRARY_FILE)
+    os.makedirs(directory, exist_ok=True)
+    existing_mode = (
+        stat.S_IMODE(os.stat(LIBRARY_FILE).st_mode) if os.path.exists(LIBRARY_FILE) else None
+    )
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=directory,
+            prefix="prompt_library_",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary_file:
+            temporary_path = temporary_file.name
+            json.dump(data, temporary_file, indent=2, ensure_ascii=False)
+            temporary_file.flush()
+            os.fsync(temporary_file.fileno())
+        if existing_mode is not None:
+            os.chmod(temporary_path, existing_mode)
+        os.replace(temporary_path, LIBRARY_FILE)
+    finally:
+        if temporary_path and os.path.exists(temporary_path):
+            os.remove(temporary_path)
 
 
 def process_random_segments(text, rng=None):
@@ -72,9 +237,20 @@ async def get_library(request):
 
 @routes.post("/prompt_library/data")
 async def save_library_route(request):
-    data = await request.json()
-    save_library(data)
-    return web.json_response({"status": "ok"})
+    try:
+        data = await request.json()
+    except Exception:
+        return web.json_response(
+            {"status": "error", "error": "The request does not contain valid JSON."}, status=400
+        )
+
+    try:
+        validated_data = validate_library(data)
+    except LibraryValidationError as error:
+        return web.json_response({"status": "error", "error": str(error)}, status=400)
+
+    save_library(validated_data)
+    return web.json_response({"status": "ok", "data": validated_data})
 
 
 @routes.post("/prompt_library/category")

--- a/web/prompt_library.css
+++ b/web/prompt_library.css
@@ -293,6 +293,14 @@
   border-color: var(--pl-accent);
   box-shadow: 0 0 0 1px var(--pl-accent-glow), 0 4px 20px rgba(0,0,0,.4);
 }
+.pl-card.selected {
+  border-color: var(--pl-accent);
+  background: var(--pl-accent-glow);
+  box-shadow: 0 0 0 1px var(--pl-accent);
+}
+.pl-card.selected .pl-card-title {
+  color: #a5b4fc;
+}
 
 .pl-card-header {
   display: flex;

--- a/web/prompt_library.css
+++ b/web/prompt_library.css
@@ -79,9 +79,11 @@
 .pl-header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   flex: 1;
+  flex-wrap: wrap;
   justify-content: flex-end;
+  min-width: 0;
 }
 
 .pl-search {
@@ -92,7 +94,9 @@
   font-family: var(--pl-font);
   font-size: 12px;
   padding: 5px 12px;
-  width: 180px;
+  width: 150px;
+  min-width: 120px;
+  flex: 1 1 150px;
   outline: none;
   transition: border-color var(--pl-transition), box-shadow var(--pl-transition);
 }
@@ -116,6 +120,16 @@
   white-space: nowrap;
 }
 .pl-btn:hover { background: #252a3a; border-color: #3d4460; }
+.pl-btn:disabled {
+  cursor: default;
+  opacity: .45;
+  pointer-events: none;
+}
+.pl-btn-compact {
+  font-size: 10px;
+  padding: 5px 8px;
+}
+.pl-file-input { display: none; }
 
 .pl-btn-accent {
   background: var(--pl-accent);
@@ -262,6 +276,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
+  min-width: 0;
+}
+.pl-selection-actions {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+}
+.pl-selection-count {
+  color: var(--pl-text-muted);
+  font-size: 10px;
+  white-space: nowrap;
 }
 .pl-count-badge {
   background: var(--pl-surface2);

--- a/web/prompt_library.js
+++ b/web/prompt_library.js
@@ -61,6 +61,7 @@ let state = {
   categories: [],
   prompts: [],
   selectedCategoryId: null,
+  selectedPromptIds: [],
   expandedCategories: new Set(),
   searchQuery: "",
   editingPrompt: null,
@@ -145,6 +146,7 @@ function showModal(content, onClose) {
 //  Main panel renderer
 // ──────────────────────────────────────────────────────────────────
 class PromptLibraryPanel {
+
   constructor(node) {
     this.node = node;
     this.container = null;
@@ -154,6 +156,15 @@ class PromptLibraryPanel {
     const data = await API.get();
     state.categories = data.categories || [];
     state.prompts = data.prompts || [];
+
+    // Sync from node if exists
+    if (this.node) {
+      const w = this.node.widgets?.find((w) => w.name === "prompt_ids");
+      if (w && w.value) {
+        state.selectedPromptIds = w.value.split(",").map(id => id.trim()).filter(Boolean);
+      }
+    }
+
     this.render();
   }
 
@@ -394,13 +405,13 @@ class PromptLibraryPanel {
 
   buildPromptCard(prompt) {
     const cat = state.categories.find((c) => c.id === prompt.category_id);
+    const isSelected = state.selectedPromptIds.includes(prompt.id);
     const card = document.createElement("div");
-    card.className = "pl-card";
+    card.className = "pl-card" + (isSelected ? " selected" : "");
     card.innerHTML = `
       <div class="pl-card-header">
         <span class="pl-card-title">${prompt.title}</span>
         <div class="pl-card-header-actions">
-          <button class="pl-icon-btn" title="Use this prompt" data-action="use">↗</button>
           <button class="pl-icon-btn" title="Edit" data-action="edit">✎</button>
           <button class="pl-icon-btn pl-icon-btn-danger" title="Delete" data-action="delete">✕</button>
         </div>
@@ -414,11 +425,14 @@ class PromptLibraryPanel {
           ? `<div class="pl-card-tags">${prompt.tags.map((t) => `<span class="pl-tag">${t}</span>`).join("")}</div>`
           : ""
       }
+      <input type="checkbox" style="display:none" ${isSelected ? "checked" : ""}>
     `;
 
-    card.querySelector("[data-action='use']").addEventListener("click", () => {
-      this.usePrompt(prompt);
+    card.addEventListener("click", (e) => {
+      if (e.target.closest(".pl-card-header-actions")) return;
+      this.togglePrompt(prompt);
     });
+
     card.querySelector("[data-action='edit']").addEventListener("click", () => {
       this.openPromptEditor(prompt);
     });
@@ -429,18 +443,33 @@ class PromptLibraryPanel {
     return card;
   }
 
-  // ── Use prompt (set node widget value) ───────────────────────────
-  usePrompt(prompt) {
-    if (this.node) {
-      // Find the prompt_id widget and set it
-      const w = this.node.widgets?.find((w) => w.name === "prompt_id");
-      if (w) {
-        w.value = prompt.id;
-        this.node.setDirtyCanvas(true);
-      }
+  // ── Toggle prompt selection ─────────────────────────────────────
+  togglePrompt(prompt) {
+    const idx = state.selectedPromptIds.indexOf(prompt.id);
+    if (idx === -1) {
+      state.selectedPromptIds.push(prompt.id);
+      this.showToast(`✓ Selected: ${prompt.title}`);
+    } else {
+      state.selectedPromptIds.splice(idx, 1);
+      this.showToast(`✕ Unselected: ${prompt.title}`);
     }
-    // Flash feedback
-    this.showToast(`✓ Loaded: ${prompt.title}`);
+
+    if (this.node) {
+      const wIds = this.node.widgets?.find((w) => w.name === "prompt_ids");
+      if (wIds) {
+        wIds.value = state.selectedPromptIds.join(",");
+      }
+
+      const wTitles = this.node.widgets?.find((w) => w.name === "prompts");
+      if (wTitles) {
+        const selectedPrompts = state.selectedPromptIds.map(id => {
+          return state.prompts.find(p => p.id === id)?.title || id;
+        });
+        wTitles.value = selectedPrompts.join(", ");
+      }
+      this.node.setDirtyCanvas(true);
+    }
+    this.render();
   }
 
   showToast(msg) {
@@ -974,6 +1003,71 @@ app.registerExtension({
         const panel = new PromptLibraryRandomPanel(this);
         panel.container = el;
         panel.init();
+      };
+    }
+
+    // ── String concatenate node ────────────────────────────────────
+    if (nodeData.name === "StringConcatenateNode") {
+      const onNodeCreated = nodeType.prototype.onNodeCreated;
+      nodeType.prototype.onNodeCreated = function () {
+        onNodeCreated?.apply(this, arguments);
+
+        const inputCountWidget = this.widgets.find((w) => w.name === "input_count");
+        const delimiterWidget = this.widgets.find((w) => w.name === "delimiter");
+        const resultWidget = this.widgets.find((w) => w.name === "result");
+
+        if (resultWidget) {
+          resultWidget.inputEl.readOnly = true;
+          resultWidget.inputEl.style.opacity = 0.7;
+        }
+
+        const syncInputs = (count) => {
+          if (!this.inputs) this.inputs = [];
+
+          // Add inputs up to count
+          for (let i = 1; i <= count; i++) {
+            const name = `string${i}`;
+            if (this.findInputSlot(name) === -1) {
+              this.addInput(name, "STRING");
+            }
+          }
+
+          // Remove inputs beyond count
+          for (let i = this.inputs.length - 1; i >= 0; i--) {
+            const name = this.inputs[i].name;
+            if (name.startsWith("string")) {
+              const num = parseInt(name.replace("string", ""));
+              if (num > count || isNaN(num)) {
+                this.removeInput(i);
+              }
+            }
+          }
+
+          this.setDirtyCanvas(true);
+        };
+
+        if (inputCountWidget) {
+          const self = this;
+          const origCallback = inputCountWidget.callback;
+          inputCountWidget.callback = function (v) {
+            const res = origCallback?.apply(this, arguments);
+            syncInputs(v);
+            return res;
+          };
+        }
+
+        if (delimiterWidget) {
+          const origCallback = delimiterWidget.callback;
+          delimiterWidget.callback = function (v) {
+            const res = origCallback?.apply(this, arguments);
+            return res;
+          };
+        }
+
+        // Initial sync
+        setTimeout(() => {
+          if (inputCountWidget) syncInputs(inputCountWidget.value);
+        }, 0);
       };
     }
   },

--- a/web/prompt_library.js
+++ b/web/prompt_library.js
@@ -4,53 +4,72 @@ import { $el } from "../../scripts/ui.js";
 // ──────────────────────────────────────────────────────────────────
 //  API helpers
 // ──────────────────────────────────────────────────────────────────
+async function parseApiResponse(response) {
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (_) {
+    // A non-JSON error response is handled by the generic message below.
+  }
+  if (!response.ok) {
+    throw new Error(payload?.error || `Request failed with status ${response.status}.`);
+  }
+  return payload;
+}
+
 const API = {
   async get() {
-    const r = await fetch("/prompt_library/data");
-    return r.json();
+    return parseApiResponse(await fetch("/prompt_library/data"));
   },
   async save(data) {
-    await fetch("/prompt_library/data", {
+    const response = await fetch("/prompt_library/data", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(data),
     });
+    return parseApiResponse(response);
   },
   async addCategory(body) {
-    const r = await fetch("/prompt_library/category", {
+    const response = await fetch("/prompt_library/category", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-    return r.json();
+    return parseApiResponse(response);
   },
   async updateCategory(id, body) {
-    await fetch(`/prompt_library/category/${id}`, {
+    const response = await fetch(`/prompt_library/category/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
+    await parseApiResponse(response);
   },
   async deleteCategory(id) {
-    await fetch(`/prompt_library/category/${id}`, { method: "DELETE" });
+    await parseApiResponse(
+      await fetch(`/prompt_library/category/${id}`, { method: "DELETE" })
+    );
   },
   async addPrompt(body) {
-    const r = await fetch("/prompt_library/prompt", {
+    const response = await fetch("/prompt_library/prompt", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
-    return r.json();
+    return parseApiResponse(response);
   },
   async updatePrompt(id, body) {
-    await fetch(`/prompt_library/prompt/${id}`, {
+    const response = await fetch(`/prompt_library/prompt/${id}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     });
+    await parseApiResponse(response);
   },
   async deletePrompt(id) {
-    await fetch(`/prompt_library/prompt/${id}`, { method: "DELETE" });
+    await parseApiResponse(
+      await fetch(`/prompt_library/prompt/${id}`, { method: "DELETE" })
+    );
   },
 };
 
@@ -123,6 +142,28 @@ function filteredPrompts() {
   return list;
 }
 
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+}
+
+function safeColor(value, fallback = "#6366f1") {
+  return /^#[0-9a-fA-F]{6}$/.test(value || "") ? value : fallback;
+}
+
+function checkImportedLibraryShape(data) {
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("The library root must be a JSON object.");
+  }
+  if (!Array.isArray(data.categories) || !Array.isArray(data.prompts)) {
+    throw new Error("The library must contain categories and prompts arrays.");
+  }
+}
+
 // ──────────────────────────────────────────────────────────────────
 //  Modal dialog
 // ──────────────────────────────────────────────────────────────────
@@ -157,12 +198,13 @@ class PromptLibraryPanel {
     state.categories = data.categories || [];
     state.prompts = data.prompts || [];
 
-    // Sync from node if exists
+    // Sync from node if it already contains a saved workflow selection.
     if (this.node) {
-      const w = this.node.widgets?.find((w) => w.name === "prompt_ids");
-      if (w && w.value) {
-        state.selectedPromptIds = w.value.split(",").map(id => id.trim()).filter(Boolean);
-      }
+      const widget = this.node.widgets?.find((item) => item.name === "prompt_ids");
+      const selectedIds = widget?.value
+        ? widget.value.split(",").map((id) => id.trim()).filter(Boolean)
+        : [];
+      this.syncPromptSelection(selectedIds, false);
     }
 
     this.render();
@@ -243,18 +285,111 @@ class PromptLibraryPanel {
         <span>Prompt Library</span>
       </div>
       <div class="pl-header-actions">
-        <input class="pl-search" placeholder="🔍  Search prompts…" value="${state.searchQuery}">
+        <input class="pl-search" placeholder="🔍  Search prompts…" value="${escapeHtml(state.searchQuery)}">
+        <button class="pl-btn pl-btn-compact" id="pl-import" title="Replace the library from a JSON file">Import</button>
+        <button class="pl-btn pl-btn-compact" id="pl-export" title="Download the current library as JSON">Export</button>
         <button class="pl-btn pl-btn-accent" id="pl-new-prompt">＋ New Prompt</button>
+        <input class="pl-file-input" id="pl-import-file" type="file" accept=".json,application/json">
       </div>
     `;
-    header.querySelector(".pl-search").addEventListener("input", (e) => {
-      state.searchQuery = e.target.value;
+    header.querySelector(".pl-search").addEventListener("input", (event) => {
+      state.searchQuery = event.target.value;
       this.render();
     });
     header.querySelector("#pl-new-prompt").addEventListener("click", () => {
       this.openPromptEditor(null);
     });
+
+    const fileInput = header.querySelector("#pl-import-file");
+    header.querySelector("#pl-import").addEventListener("click", () => fileInput.click());
+    fileInput.addEventListener("change", async (event) => {
+      const file = event.target.files?.[0];
+      event.target.value = "";
+      if (file) await this.prepareImport(file);
+    });
+    header.querySelector("#pl-export").addEventListener("click", (event) => {
+      this.exportLibrary(event.currentTarget);
+    });
     return header;
+  }
+
+  async prepareImport(file) {
+    let importedData;
+    try {
+      importedData = JSON.parse(await file.text());
+      checkImportedLibraryShape(importedData);
+    } catch (error) {
+      const message = error instanceof SyntaxError ? "The selected file is not valid JSON." : error.message;
+      this.showToast(`Import failed: ${message}`);
+      return;
+    }
+
+    const content = `
+      <div class="pl-modal-header"><h2>Import Prompt Library</h2><button class="pl-modal-close" id="mclose">✕</button></div>
+      <div class="pl-form">
+        <p>Replace the complete current library with <strong>${importedData.categories.length}</strong> categories and <strong>${importedData.prompts.length}</strong> prompts?</p>
+        <p class="pl-warn">⚠ Existing categories and prompts will be replaced. Export a backup first if needed.</p>
+        <div class="pl-form-actions">
+          <button class="pl-btn" id="f-cancel">Cancel</button>
+          <button class="pl-btn pl-btn-accent" id="f-confirm">Import and Replace</button>
+        </div>
+      </div>
+    `;
+    const { modal, close } = showModal(content);
+    modal.querySelector("#mclose").addEventListener("click", close);
+    modal.querySelector("#f-cancel").addEventListener("click", close);
+    modal.querySelector("#f-confirm").addEventListener("click", async (event) => {
+      const button = event.currentTarget;
+      button.disabled = true;
+      button.textContent = "Importing…";
+      try {
+        const response = await API.save(importedData);
+        const acceptedData = response?.data || importedData;
+        state.categories = acceptedData.categories;
+        state.prompts = acceptedData.prompts;
+        state.selectedCategoryId = null;
+        state.expandedCategories = new Set();
+        state.searchQuery = "";
+        const searchInput = this.container?.querySelector(".pl-search");
+        if (searchInput) searchInput.value = "";
+        this.syncPromptSelection(state.selectedPromptIds);
+        close();
+        this.render();
+        this.showToast(
+          `Imported ${state.categories.length} categories and ${state.prompts.length} prompts.`
+        );
+      } catch (error) {
+        button.disabled = false;
+        button.textContent = "Import and Replace";
+        this.showToast(`Import failed: ${error.message}`);
+      }
+    });
+  }
+
+  async exportLibrary(button) {
+    const originalText = button.textContent;
+    button.disabled = true;
+    button.textContent = "Exporting…";
+    try {
+      const data = await API.get();
+      const json = `${JSON.stringify(data, null, 2)}\n`;
+      const blob = new Blob([json], { type: "application/json;charset=utf-8" });
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = "prompt_library_data.json";
+      anchor.style.display = "none";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+      this.showToast("Prompt library exported.");
+    } catch (error) {
+      this.showToast(`Export failed: ${error.message}`);
+    } finally {
+      button.disabled = false;
+      button.textContent = originalText;
+    }
   }
 
   // ── Sidebar (categories tree) ────────────────────────────────────
@@ -311,8 +446,8 @@ class PromptLibraryPanel {
 
     row.innerHTML = `
       <span class="pl-cat-toggle">${hasChildren ? (expanded ? "▾" : "▸") : "·"}</span>
-      <span class="pl-cat-dot" style="background:${cat.color || "#6366f1"}"></span>
-      <span class="pl-cat-label">${cat.name}</span>
+      <span class="pl-cat-dot" style="background:${safeColor(cat.color)}"></span>
+      <span class="pl-cat-label">${escapeHtml(cat.name)}</span>
       <span class="pl-cat-count">${count}</span>
       <span class="pl-cat-actions">
         <button class="pl-icon-btn" title="Add sub-category" data-action="add-sub">＋</button>
@@ -374,9 +509,21 @@ class PromptLibraryPanel {
         ? state.categories.find((c) => c.id === state.selectedCategoryId)?.name || "Unknown"
         : "All Prompts";
 
+    const selectedCount = state.selectedPromptIds.length;
     const bar = document.createElement("div");
     bar.className = "pl-content-bar";
-    bar.innerHTML = `<h3 class="pl-content-title">${catName} <span class="pl-count-badge">${prompts.length}</span></h3>`;
+    bar.innerHTML = `
+      <h3 class="pl-content-title">${escapeHtml(catName)} <span class="pl-count-badge">${prompts.length}</span></h3>
+      <div class="pl-selection-actions">
+        <span class="pl-selection-count">${selectedCount} selected</span>
+        <button class="pl-btn pl-btn-compact" id="pl-clear-selection" ${selectedCount ? "" : "disabled"}>Clear selection</button>
+      </div>
+    `;
+    bar.querySelector("#pl-clear-selection").addEventListener("click", () => {
+      this.syncPromptSelection([]);
+      this.render();
+      this.showToast("Prompt selection cleared.");
+    });
     content.appendChild(bar);
 
     if (prompts.length === 0) {
@@ -405,24 +552,25 @@ class PromptLibraryPanel {
 
   buildPromptCard(prompt) {
     const cat = state.categories.find((c) => c.id === prompt.category_id);
+    const categoryColor = safeColor(cat?.color);
     const isSelected = state.selectedPromptIds.includes(prompt.id);
     const card = document.createElement("div");
     card.className = "pl-card" + (isSelected ? " selected" : "");
     card.innerHTML = `
       <div class="pl-card-header">
-        <span class="pl-card-title">${prompt.title}</span>
+        <span class="pl-card-title">${escapeHtml(prompt.title)}</span>
         <div class="pl-card-header-actions">
           <button class="pl-icon-btn" title="Edit" data-action="edit">✎</button>
           <button class="pl-icon-btn pl-icon-btn-danger" title="Delete" data-action="delete">✕</button>
         </div>
       </div>
-      ${cat ? `<div class="pl-card-cat" style="background:${cat.color}22;color:${cat.color}">
-        <span class="pl-card-dot" style="background:${cat.color}"></span>${cat.name}</div>` : ""}
-      <p class="pl-card-text">${prompt.text}</p>
-      ${prompt.negative ? `<p class="pl-card-neg"><span>neg:</span> ${prompt.negative}</p>` : ""}
+      ${cat ? `<div class="pl-card-cat" style="background:${categoryColor}22;color:${categoryColor}">
+        <span class="pl-card-dot" style="background:${categoryColor}"></span>${escapeHtml(cat.name)}</div>` : ""}
+      <p class="pl-card-text">${escapeHtml(prompt.text)}</p>
+      ${prompt.negative ? `<p class="pl-card-neg"><span>neg:</span> ${escapeHtml(prompt.negative)}</p>` : ""}
       ${
         prompt.tags?.length
-          ? `<div class="pl-card-tags">${prompt.tags.map((t) => `<span class="pl-tag">${t}</span>`).join("")}</div>`
+          ? `<div class="pl-card-tags">${prompt.tags.map((tag) => `<span class="pl-tag">${escapeHtml(tag)}</span>`).join("")}</div>`
           : ""
       }
       <input type="checkbox" style="display:none" ${isSelected ? "checked" : ""}>
@@ -443,32 +591,37 @@ class PromptLibraryPanel {
     return card;
   }
 
-  // ── Toggle prompt selection ─────────────────────────────────────
+  // ── Prompt selection ────────────────────────────────────────────
+  syncPromptSelection(selectedIds, markDirty = true) {
+    const validPromptIds = new Set(state.prompts.map((prompt) => prompt.id));
+    state.selectedPromptIds = [...new Set(selectedIds)].filter((id) => validPromptIds.has(id));
+
+    if (this.node) {
+      const idsWidget = this.node.widgets?.find((widget) => widget.name === "prompt_ids");
+      if (idsWidget) idsWidget.value = state.selectedPromptIds.join(",");
+
+      const titlesWidget = this.node.widgets?.find((widget) => widget.name === "prompts");
+      if (titlesWidget) {
+        titlesWidget.value = state.selectedPromptIds
+          .map((id) => state.prompts.find((prompt) => prompt.id === id)?.title || id)
+          .join(", ");
+      }
+      if (markDirty) this.node.setDirtyCanvas?.(true);
+    }
+  }
+
   togglePrompt(prompt) {
-    const idx = state.selectedPromptIds.indexOf(prompt.id);
-    if (idx === -1) {
-      state.selectedPromptIds.push(prompt.id);
+    const selectedIds = [...state.selectedPromptIds];
+    const index = selectedIds.indexOf(prompt.id);
+    if (index === -1) {
+      selectedIds.push(prompt.id);
       this.showToast(`✓ Selected: ${prompt.title}`);
     } else {
-      state.selectedPromptIds.splice(idx, 1);
+      selectedIds.splice(index, 1);
       this.showToast(`✕ Unselected: ${prompt.title}`);
     }
 
-    if (this.node) {
-      const wIds = this.node.widgets?.find((w) => w.name === "prompt_ids");
-      if (wIds) {
-        wIds.value = state.selectedPromptIds.join(",");
-      }
-
-      const wTitles = this.node.widgets?.find((w) => w.name === "prompts");
-      if (wTitles) {
-        const selectedPrompts = state.selectedPromptIds.map(id => {
-          return state.prompts.find(p => p.id === id)?.title || id;
-        });
-        wTitles.value = selectedPrompts.join(", ");
-      }
-      this.node.setDirtyCanvas(true);
-    }
+    this.syncPromptSelection(selectedIds);
     this.render();
   }
 
@@ -491,7 +644,7 @@ class PromptLibraryPanel {
     const catOptions = state.categories
       .map(
         (c) =>
-          `<option value="${c.id}" ${existing?.category_id === c.id ? "selected" : ""}>${c.name}</option>`
+          `<option value="${escapeHtml(c.id)}" ${existing?.category_id === c.id ? "selected" : ""}>${escapeHtml(c.name)}</option>`
       )
       .join("");
 
@@ -499,7 +652,7 @@ class PromptLibraryPanel {
       <div class="pl-modal-header"><h2>${title}</h2><button class="pl-modal-close" id="mclose">✕</button></div>
       <div class="pl-form">
         <label>Title *</label>
-        <input id="f-title" class="pl-input" value="${existing?.title || ""}">
+        <input id="f-title" class="pl-input" value="${escapeHtml(existing?.title)}">
         
         <label>Category</label>
         <select id="f-cat" class="pl-input">
@@ -508,13 +661,13 @@ class PromptLibraryPanel {
         </select>
         
         <label>Positive Prompt *</label>
-        <textarea id="f-text" class="pl-textarea" rows="6">${existing?.text || ""}</textarea>
+        <textarea id="f-text" class="pl-textarea" rows="6">${escapeHtml(existing?.text)}</textarea>
         
         <label>Negative Prompt</label>
-        <textarea id="f-neg" class="pl-textarea" rows="3">${existing?.negative || ""}</textarea>
+        <textarea id="f-neg" class="pl-textarea" rows="3">${escapeHtml(existing?.negative)}</textarea>
         
         <label>Tags <span style="opacity:.5;font-size:11px">(comma separated)</span></label>
-        <input id="f-tags" class="pl-input" value="${(existing?.tags || []).join(", ")}">
+        <input id="f-tags" class="pl-input" value="${escapeHtml((existing?.tags || []).join(", "))}">
         
         <div class="pl-form-actions">
           <button class="pl-btn" id="f-cancel">Cancel</button>
@@ -546,12 +699,13 @@ class PromptLibraryPanel {
           .filter(Boolean),
       };
       if (isNew) {
-        const p = await API.addPrompt(body);
-        state.prompts.push(p);
+        const prompt = await API.addPrompt(body);
+        state.prompts.push(prompt);
       } else {
         await API.updatePrompt(existing.id, body);
         Object.assign(existing, body);
       }
+      this.syncPromptSelection(state.selectedPromptIds);
       close();
       this.render();
     });
@@ -561,7 +715,7 @@ class PromptLibraryPanel {
   openCategoryEditor(existing, parentId) {
     const isNew = !existing;
     const colors = ["#6366f1","#ec4899","#f59e0b","#10b981","#3b82f6","#ef4444","#8b5cf6","#14b8a6"];
-    const selectedColor = existing?.color || colors[0];
+    const selectedColor = safeColor(existing?.color, colors[0]);
 
     const content = `
       <div class="pl-modal-header">
@@ -570,7 +724,7 @@ class PromptLibraryPanel {
       </div>
       <div class="pl-form">
         <label>Name *</label>
-        <input id="f-catname" class="pl-input" value="${existing?.name || ""}">
+        <input id="f-catname" class="pl-input" value="${escapeHtml(existing?.name)}">
         
         <label>Color</label>
         <div class="pl-color-picker" id="f-colorpicker">
@@ -627,7 +781,7 @@ class PromptLibraryPanel {
     const content = `
       <div class="pl-modal-header"><h2>Delete Category</h2><button class="pl-modal-close" id="mclose">✕</button></div>
       <div class="pl-form">
-        <p>Delete <strong>${cat.name}</strong>?</p>
+        <p>Delete <strong>${escapeHtml(cat.name)}</strong>?</p>
         ${subs ? `<p class="pl-warn">⚠ This will also delete <strong>${subs}</strong> sub-categor${subs > 1 ? "ies" : "y"}.</p>` : ""}
         ${prompts ? `<p class="pl-warn">⚠ This will also delete <strong>${prompts}</strong> prompt${prompts > 1 ? "s" : ""}.</p>` : ""}
         <div class="pl-form-actions">
@@ -645,6 +799,7 @@ class PromptLibraryPanel {
       state.categories = state.categories.filter((c) => !ids.includes(c.id));
       state.prompts = state.prompts.filter((p) => !ids.includes(p.category_id));
       if (ids.includes(state.selectedCategoryId)) state.selectedCategoryId = null;
+      this.syncPromptSelection(state.selectedPromptIds);
       close();
       this.render();
     });
@@ -654,7 +809,7 @@ class PromptLibraryPanel {
     const content = `
       <div class="pl-modal-header"><h2>Delete Prompt</h2><button class="pl-modal-close" id="mclose">✕</button></div>
       <div class="pl-form">
-        <p>Delete <strong>${prompt.title}</strong>?</p>
+        <p>Delete <strong>${escapeHtml(prompt.title)}</strong>?</p>
         <div class="pl-form-actions">
           <button class="pl-btn" id="f-cancel">Cancel</button>
           <button class="pl-btn pl-btn-danger" id="f-confirm">Delete</button>
@@ -666,7 +821,8 @@ class PromptLibraryPanel {
     modal.querySelector("#f-cancel").addEventListener("click", close);
     modal.querySelector("#f-confirm").addEventListener("click", async () => {
       await API.deletePrompt(prompt.id);
-      state.prompts = state.prompts.filter((p) => p.id !== prompt.id);
+      state.prompts = state.prompts.filter((item) => item.id !== prompt.id);
+      this.syncPromptSelection(state.selectedPromptIds);
       close();
       this.render();
     });
@@ -829,8 +985,8 @@ class PromptLibraryRandomPanel {
     row.innerHTML = `
       <span class="plr-toggle">${hasChildren ? (expanded ? "▾" : "▸") : "·"}</span>
       <input type="checkbox" class="plr-check" ${checked ? "checked" : ""}>
-      <span class="plr-cat-dot" style="background:${cat.color || "#6366f1"}"></span>
-      <span class="plr-cat-name">${cat.name}</span>
+      <span class="plr-cat-dot" style="background:${safeColor(cat.color)}"></span>
+      <span class="plr-cat-name">${escapeHtml(cat.name)}</span>
       <span class="plr-cat-n">${subtreeCount}</span>
     `;
 
@@ -889,9 +1045,9 @@ class PromptLibraryRandomPanel {
       const item = document.createElement("div");
       item.className = "plr-pool-item";
       item.innerHTML = `
-        <span class="plr-pool-dot" style="background:${cat?.color || "#888"}"></span>
-        <span class="plr-pool-title">${p.title}</span>
-        ${cat ? `<span class="plr-pool-cat">${cat.name}</span>` : ""}
+        <span class="plr-pool-dot" style="background:${safeColor(cat?.color, "#888888")}"></span>
+        <span class="plr-pool-title">${escapeHtml(p.title)}</span>
+        ${cat ? `<span class="plr-pool-cat">${escapeHtml(cat.name)}</span>` : ""}
       `;
       list.appendChild(item);
     });


### PR DESCRIPTION
Forked from NoudH’s master branch (https://github.com/NoudH/ComfyUI-Prompt-Library), which includes multi-select support and the String Concatenate node.
- Added Import and Export buttons, allowing users to back up and restore their entire prompt library.
- Added a Clear Selection button so users can quickly reset selected prompts, even while viewing a different category.
- Moved prompt_library_data.json to the configured ComfyUI user directory, keeping user data separate from the custom node’s source files.